### PR TITLE
Fix compile issue on musl-libc environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EthUDP:EthUDP.c
-	gcc -g -Wall -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto
+	gcc -g -Wall -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto -D_GNU_SOURCE
 indent: EthUDP.c
 	indent EthUDP.c  -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4  \
 -cli0 -d0 -di1 -nfc1 -i8 -ip0 -l160 -lp -npcs -nprs -npsl -sai \


### PR DESCRIPTION
While building with musl-libc:

```
~/ethudp # make
gcc -g -Wall -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto
EthUDP.c: In function 'fix_mss':
EthUDP.c:689:12: error: 'struct tcphdr' has no member named 'syn'
   if (!tcph->syn)
            ^~
EthUDP.c:695:43: error: 'struct tcphdr' has no member named 'doff'; did you mean 'th_off'?
   for (i = sizeof(struct tcphdr); i < tcph->doff * 4; i += optlen(opt, i)) {
                                           ^~
EthUDP.c:696:27: error: 'struct tcphdr' has no member named 'doff'; did you mean 'th_off'?
    if (opt[i] == 2 && tcph->doff * 4 - i >= 4 && // TCP_MSS
                           ^~
EthUDP.c:716:9: error: 'struct tcphdr' has no member named 'check'; did you mean 'th_ack'?
     tcph->check = 0; /* Checksum field has to be set to 0 before checksumming */
         ^~
EthUDP.c:717:9: error: 'struct tcphdr' has no member named 'check'; did you mean 'th_ack'?
     tcph->check = (u_int16_t)
         ^~
EthUDP.c:737:12: error: 'struct tcphdr' has no member named 'syn'
   if (!tcph->syn)
            ^~
EthUDP.c:741:43: error: 'struct tcphdr' has no member named 'doff'; did you mean 'th_off'?
   for (i = sizeof(struct tcphdr); i < tcph->doff * 4; i += optlen(opt, i)) {
                                           ^~
EthUDP.c:742:27: error: 'struct tcphdr' has no member named 'doff'; did you mean 'th_off'?
    if (opt[i] == 2 && tcph->doff * 4 - i >= 4 && // TCP_MSS
                           ^~
EthUDP.c:763:9: error: 'struct tcphdr' has no member named 'check'; did you mean 'th_ack'?
     tcph->check = 0; /* Checksum field has to be set to 0 before checksumming */
         ^~
EthUDP.c:764:9: error: 'struct tcphdr' has no member named 'check'; did you mean 'th_ack'?
     tcph->check = (u_int16_t) tcp_sum_calc_v6((u_int16_t)
         ^~
make: *** [Makefile:2: EthUDP] Error 1
```

Add `-D_GNU_SOURCE` macro flag for gcc would fix the problem.