### PR TITLE
Make GIT_VERSION and CC externally configurable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+GIT_VERSION ?= $(shell git describe --abbrev=4 --dirty --always --tags)
+CC ?= gcc
 
 EthUDP:EthUDP.c
-	gcc -g -Wall -DVERSION=\"$(GIT_VERSION)\" -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto -lpcap -D_GNU_SOURCE
+	$(CC) -g -Wall -DVERSION=\"$(GIT_VERSION)\" -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto -lpcap -D_GNU_SOURCE
 
 run:
-	gcc -Wall -DVERSION=\"$(GIT_VERSION)-O3\" -Wunused-result -fno-strict-aliasing -O2 -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto -lpcap -D_GNU_SOURCE
+	$(CC) -Wall -DVERSION=\"$(GIT_VERSION)-O3\" -Wunused-result -fno-strict-aliasing -O2 -o EthUDP EthUDP.c -lpthread -lssl -llz4 -lcrypto -lpcap -D_GNU_SOURCE
 
 indent: EthUDP.c
 	indent EthUDP.c  -nbad -bap -nbc -bbo -hnl -br -brs -c33 -cd33 -ncdb -ce -ci4  \


### PR DESCRIPTION
This PR allows to specify GIT_VERSION and CC when building the project.
This makes it possible to include in Buildroot without patching.
